### PR TITLE
prisma をバージョンダウン

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "5.12.1",
+    "@prisma/client": "5.9.1",
     "http-auth": "4.2.0",
-    "prisma": "5.12.1",
+    "prisma": "5.9.1",
     "pug": "3.0.2"
   }
 }


### PR DESCRIPTION
#1 でバージョンアップいただいたのですが、教材よりも新しいバージョンが使われていたためバージョンダウンしました。

教材では prisma@5.9.1 を使用しています。
https://github.com/progedu/intro-2024-edition/issues/37